### PR TITLE
Delegate render scheduler

### DIFF
--- a/src/delegate-render-scheduler.spec.ts
+++ b/src/delegate-render-scheduler.spec.ts
@@ -1,0 +1,87 @@
+import type { DelegateRenderScheduler } from './delegate-render-scheduler';
+import { newDelegateRenderScheduler } from './delegate-render-scheduler';
+import type { ManualRenderScheduler } from './manual-render-scheduler';
+import { newManualRenderScheduler } from './manual-render-scheduler';
+import type { RenderScheduler } from './render-scheduler';
+
+describe('DelegateRenderScheduler', () => {
+
+  let scheduler: ManualRenderScheduler;
+  let delegate: DelegateRenderScheduler;
+  let scheduleBy: (scheduler: RenderScheduler) => DelegateRenderScheduler;
+
+  beforeEach(() => {
+    scheduler = newManualRenderScheduler();
+    delegate = newDelegateRenderScheduler(scheduler);
+    scheduleBy = delegate.scheduleBy;
+  });
+
+  let out: number[];
+
+  beforeEach(() => {
+    out = [];
+  });
+
+  it('schedules rendering by another scheduler', () => {
+
+    const schedule = delegate();
+
+    schedule(() => out.push(1));
+    expect(out).toHaveLength(0);
+
+    scheduler.render();
+    expect(out).toEqual([1]);
+  });
+
+  describe('scheduleBy', () => {
+
+    let scheduler2: ManualRenderScheduler;
+
+    beforeEach(() => {
+      scheduler2 = newManualRenderScheduler();
+    });
+
+    it('creates new schedules in new scheduler', () => {
+
+      expect(out).toHaveLength(0);
+      expect(scheduleBy(scheduler2)).toBe(delegate);
+
+      const schedule = delegate();
+
+      schedule(() => out.push(1));
+      scheduler.render();
+      expect(out).toHaveLength(0);
+
+      scheduler2.render();
+      expect(out).toEqual([1]);
+    });
+    it('schedules new render shots by new scheduler', () => {
+
+      const schedule = delegate();
+
+      expect(out).toHaveLength(0);
+      expect(scheduleBy(scheduler2)).toBe(delegate);
+
+      schedule(() => out.push(1));
+      scheduler.render();
+      expect(out).toHaveLength(0);
+
+      scheduler2.render();
+      expect(out).toEqual([1]);
+    });
+    it('schedules old render shots by old scheduler', () => {
+
+      const schedule = delegate();
+
+      schedule(() => out.push(1));
+      expect(out).toHaveLength(0);
+      expect(scheduleBy(scheduler2)).toBe(delegate);
+
+      scheduler.render();
+      expect(out).toEqual([1]);
+
+      scheduler2.render();
+      expect(out).toEqual([1]);
+    });
+  });
+});

--- a/src/delegate-render-scheduler.ts
+++ b/src/delegate-render-scheduler.ts
@@ -1,0 +1,70 @@
+import type { RenderSchedule, RenderScheduleOptions } from './render-schedule';
+import type { RenderScheduler } from './render-scheduler';
+import type { RenderExecution } from './render-shot';
+
+/**
+ * A render scheduler that schedules rendering by another one.
+ *
+ * The target scheduler can be switched at any time.
+ *
+ * Can be constructed by {@link newDelegateRenderScheduler} function.
+ *
+ * @typeParam TExecution - A type of supported render shot execution context.
+ * @typeParam TOptions - A type of accepted render schedule options.
+ */
+export interface DelegateRenderScheduler<
+    TExecution extends RenderExecution = RenderExecution,
+    TOptions extends RenderScheduleOptions = RenderScheduleOptions>
+    extends RenderScheduler<TExecution, TOptions> {
+
+  /**
+   * Switches a render scheduler to schedule rendering by.
+   *
+   * The previously scheduled render shots would still be executed by previous scheduler.
+   *
+   * Does nothing if the target scheduler is the same as previous one.
+   *
+   * @param scheduler - A render scheduler to delegate scheduling to from now on.
+   *
+   * @returns `this` instance.
+   */
+  scheduleBy(this: void, scheduler: RenderScheduler<TExecution>): this;
+
+}
+
+/**
+ * Creates a render scheduler that delegates scheduling to the given one.
+ *
+ * @param scheduler - A A render scheduler to delegate scheduling to.
+ *
+ * @typeParam TExecution - A type of supported render shot execution context.
+ * @typeParam TOptions - A type of accepted render schedule options.
+ */
+export function newDelegateRenderScheduler<
+    TExecution extends RenderExecution,
+    TOptions extends RenderScheduleOptions = RenderScheduleOptions>(
+    scheduler: RenderScheduler<TExecution>,
+): DelegateRenderScheduler<TExecution, TOptions> {
+
+  const result = ((options: TOptions): RenderSchedule<TExecution> => {
+
+    let usedScheduler = scheduler;
+    let schedule = scheduler(options);
+
+    return shot => {
+      if (usedScheduler !== scheduler) {
+        usedScheduler = scheduler;
+        schedule = scheduler(options);
+      }
+
+      schedule(shot);
+    };
+  }) as DelegateRenderScheduler<TExecution, TOptions>;
+
+  result.scheduleBy = newScheduler => {
+    scheduler = newScheduler;
+    return result;
+  };
+
+  return result;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@
 export * from './animation-render-scheduler';
 export * from './async-render-scheduler';
 export * from './custom-render-scheduler';
+export * from './delegate-render-scheduler';
 export * from './immediate-render-scheduler';
 export * from './manual-render-scheduler';
 export * from './noop-render-scheduler';

--- a/src/manual-render-scheduler.spec.ts
+++ b/src/manual-render-scheduler.spec.ts
@@ -4,17 +4,19 @@ import type { RenderSchedule } from './render-schedule';
 describe('manualRenderScheduler', () => {
 
   let scheduler: ManualRenderScheduler;
+  let render: () => boolean;
   let schedule: RenderSchedule;
   let schedule2: RenderSchedule;
 
   beforeEach(() => {
     scheduler = newManualRenderScheduler();
+    render = scheduler.render;
     schedule = scheduler();
     schedule2 = scheduler();
   });
 
   it('returns `false` when no render shots scheduled', () => {
-    expect(scheduler.render()).toBe(false);
+    expect(render()).toBe(false);
   });
   it('executes scheduled render shots by request', () => {
 
@@ -30,12 +32,12 @@ describe('manualRenderScheduler', () => {
     expect(shot2).not.toHaveBeenCalled();
     expect(shot3).not.toHaveBeenCalled();
 
-    expect(scheduler.render()).toBe(true);
+    expect(render()).toBe(true);
     expect(shot1).toHaveBeenCalled();
     expect(shot2).not.toHaveBeenCalled();
     expect(shot3).toHaveBeenCalled();
 
-    expect(scheduler.render()).toBe(false);
+    expect(render()).toBe(false);
     expect(shot1).toHaveBeenCalledTimes(1);
     expect(shot2).not.toHaveBeenCalled();
     expect(shot3).toHaveBeenCalledTimes(1);
@@ -53,7 +55,7 @@ describe('manualRenderScheduler', () => {
     expect(postponed1).not.toHaveBeenCalled();
     expect(postponed2).not.toHaveBeenCalled();
 
-    scheduler.render();
+    render();
     expect(postponed1).toHaveBeenCalledTimes(1);
     expect(postponed2).toHaveBeenCalledTimes(1);
   });
@@ -72,16 +74,16 @@ describe('manualRenderScheduler', () => {
     expect(shot2).not.toHaveBeenCalled();
     expect(shot3).not.toHaveBeenCalled();
 
-    expect(scheduler.render()).toBe(true);
+    expect(render()).toBe(true);
     expect(shot1).toHaveBeenCalled();
     expect(shot2).not.toHaveBeenCalled();
     expect(shot3).not.toHaveBeenCalled();
 
-    expect(scheduler.render()).toBe(true);
+    expect(render()).toBe(true);
     expect(shot2).not.toHaveBeenCalled();
     expect(shot3).toHaveBeenCalled();
 
-    expect(scheduler.render()).toBe(false);
+    expect(render()).toBe(false);
     expect(shot1).toHaveBeenCalledTimes(1);
     expect(shot2).not.toHaveBeenCalled();
     expect(shot3).toHaveBeenCalledTimes(1);
@@ -101,12 +103,12 @@ describe('manualRenderScheduler', () => {
     expect(shot2).not.toHaveBeenCalled();
     expect(shot3).not.toHaveBeenCalled();
 
-    expect(scheduler.render()).toBe(true);
+    expect(render()).toBe(true);
     expect(shot1).toHaveBeenCalled();
     expect(shot2).not.toHaveBeenCalled();
     expect(shot3).toHaveBeenCalled();
 
-    expect(scheduler.render()).toBe(false);
+    expect(render()).toBe(false);
     expect(shot1).toHaveBeenCalledTimes(1);
     expect(shot2).not.toHaveBeenCalled();
     expect(shot3).toHaveBeenCalledTimes(1);
@@ -131,7 +133,7 @@ describe('manualRenderScheduler', () => {
       schedule3(recurrent2);
     });
 
-    scheduler.render();
+    render();
     expect(calls).toEqual(['recurrent1', 'recurrent2', 'postponed']);
   });
   it('logs errors according to schedule options', () => {
@@ -147,7 +149,7 @@ describe('manualRenderScheduler', () => {
     schedule(() => { throw error; });
     schedule2(() => { throw error; });
 
-    scheduler.render();
+    render();
     expect(logError1).toHaveBeenCalledWith(error);
     expect(logError1).toHaveBeenCalledTimes(1);
     expect(logError2).toHaveBeenCalledWith(error);
@@ -167,7 +169,7 @@ describe('manualRenderScheduler', () => {
     schedule(shot1);
     schedule2(shot2);
 
-    scheduler.render();
+    render();
     expect(shot1).toHaveBeenCalledWith(expect.objectContaining({ config: expect.objectContaining(options1) }));
     expect(shot2).toHaveBeenCalledWith(expect.objectContaining({ config: expect.objectContaining(options2) }));
   });

--- a/src/manual-render-scheduler.ts
+++ b/src/manual-render-scheduler.ts
@@ -14,7 +14,7 @@ export interface ManualRenderScheduler extends RenderScheduler {
    *
    * @returns `true` if some render shots executed, or `false` when no render shots scheduled.
    */
-  render(): boolean;
+  render(this: void): boolean;
 
 }
 

--- a/src/render-scheduler.ts
+++ b/src/render-scheduler.ts
@@ -20,14 +20,17 @@ import type { RenderExecution } from './render-shot';
  * Custom scheduler implementations could be created using {@link customRenderScheduler} function.
  *
  * @typeParam TExecution - A type of supported render shot execution context.
+ * @typeParam TOptions - A type of accepted render schedule options.
  */
-export type RenderScheduler<TExecution extends RenderExecution = RenderExecution> =
+export type RenderScheduler<
+    TExecution extends RenderExecution = RenderExecution,
+    TOptions extends RenderScheduleOptions = RenderScheduleOptions> =
 /**
  * @param options - Options of constructed render schedule.
  *
  * @returns New render schedule.
  */
-    (this: void, options?: RenderScheduleOptions) => RenderSchedule<TExecution>;
+    (this: void, options?: TOptions) => RenderSchedule<TExecution>;
 
 /**
  * @internal


### PR DESCRIPTION
- `ManualRenderShot.render()` does not require `this` parameter
- Add generic type parameter for schedule options type
- Implement `DelegateRenderScheduler`
